### PR TITLE
Module additions and modifications to PowerShell script

### DIFF
--- a/POSIX/NodePingPUSHClient/modules/apcupsd.sh
+++ b/POSIX/NodePingPUSHClient/modules/apcupsd.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Checks the status of APC battery banks. Requires apcupsd is installed
+# and the apcaccess command is available. If the state changes to
+# something other than ONLINE, a fail is sent.
+
+status=$(apcaccess status | grep "STATUS" | awk '{printf $3}' | xargs)
+
+if [ "$status" = "ONLINE" ]; then
+    echo "1"
+else
+    echo "0"
+fi

--- a/POSIX/NodePingPUSHClient/modules/checksum.sh
+++ b/POSIX/NodePingPUSHClient/modules/checksum.sh
@@ -7,9 +7,8 @@
 # enter the filename and checksum on a new line each.
 # Set the permissions to 0400 when finished adding data.
 
-hash_type="sha256"
-hash_file="checksum.txt"
-full_path="$(dirname "$(readlink -f $hash_file)")/$hash_file"
+hash_type="md5"
+full_path="$(dirname $0)/checksum.txt"
 
 OS=$(uname)
 

--- a/POSIX/NodePingPUSHClient/modules/checksum.sh
+++ b/POSIX/NodePingPUSHClient/modules/checksum.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env sh
+
+# This module will alert you if a file checksum has
+# changed for the specified files. If no hash is provided, defaults to SHA256
+# Each file must have the pattern of '/path/to/file checksum'
+# Create a "checksum.txt" file in the same directory as this module and
+# enter the filename and checksum on a new line each.
+# Set the permissions to 0400 when finished adding data.
+
+hash_type="sha256"
+hash_file="checksum.txt"
+full_path="$(dirname "$(readlink -f $hash_file)")/$hash_file"
+
+OS=$(uname)
+
+sep=''
+
+file_seps=$(echo $files | grep -o ';' | wc -l)
+
+if [ $OS = "Linux" ]; then
+    if [ $hash_type = "sha1" ]; then
+	command="sha1sum"
+    elif [ $hash_type = "sha256" ]; then
+	command="sha256sum"
+    elif [ $hash_type = "sha512" ]; then
+	command="sha512sum"
+    elif [ $hash_type = "md5" ]; then
+	command="md5sum"
+    else
+	command="sha256sum"
+    fi
+elif [ $OS = "FreeBSD" ]; then
+    if [ $hash_type = "sha1" ]; then
+	command="sha1"
+    elif [ $hash_type = "sha256" ]; then
+	command="sha256"
+    elif [ $hash_type = "sha512" ]; then
+	command="sha512"
+    elif [ $hash_type = "md5" ]; then
+	command="md5"
+    else
+	command="sha256"
+    fi
+fi
+
+echo '{'
+
+cat $full_path | while read -r line; do
+    name=$(echo $line | awk '{printf $1}')
+    checksum=$(echo $line | awk '{printf $2}')
+
+    echo "$sep"
+
+    if [ -f $name ]; then
+	if [ $OS = "Linux" ]; then
+	    run_sum=$($command $name | awk '{printf $1}')
+	elif [ $OS = "FreeBSD" ]; then
+	    run_sum=$($command $name | awk '{printf $4}')
+	fi
+
+	if [ "$run_sum" = "$checksum" ]; then
+	    echo -n "\"$name\":1"
+	else
+	    echo -n "\"$name\":0"
+	fi
+    else
+	echo -n "\"$name\":0"
+    fi
+
+    sep=','
+    
+done
+
+echo '}'
+    

--- a/POSIX/NodePingPUSHClient/modules/checksum.txt
+++ b/POSIX/NodePingPUSHClient/modules/checksum.txt
@@ -1,0 +1,3 @@
+/path/to/file1 checksum
+/path/to/file2 checksum
+/path/to/file3 checksum

--- a/POSIX/NodePingPUSHClient/modules/fileage.sh
+++ b/POSIX/NodePingPUSHClient/modules/fileage.sh
@@ -7,7 +7,7 @@
 
 file1="/path/to/file1 0 5 0"
 file2="/path/to/file2 0 2 30"
-file3="/home/courtney/the_wardrobe.tar.gz 10 6 0"
+file3="/path/to/file3 10 6 0"
 
 files="$file1;$file2;$file3"
 

--- a/PowerShell/NodePingPowerShellPUSH/NodePingPUSH.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/NodePingPUSH.ps1
@@ -18,7 +18,7 @@ $result = @{
 foreach( $module in $modules )
 {
 	$script = $module.Arguments
-	$output = & .\$script 2>&1 | Out-String
+	$output = & .\$script 2>&1 | ConvertTo-Json -Compress | Out-String
 
 	$result.data[ $module.Name ] = $output | ConvertFrom-Json
 }

--- a/PowerShell/NodePingPowerShellPUSH/modules/checksum.json
+++ b/PowerShell/NodePingPowerShellPUSH/modules/checksum.json
@@ -1,0 +1,14 @@
+[
+	{ 
+		"FileName": "C:\\Users\\Administrator\\Documents\\hello.txt",
+		"Hash": "hash1"
+	},
+	{ 
+		"FileName": "C:\\Users\\Administrator\\Desktop\\file1.docx",
+		"Hash": "hash2"
+	},
+	{ 
+		"FileName": "C:\\Users\\Administrator\\Documents\\fileage.ps1",
+		"Hash": "hash3"
+	}
+]

--- a/PowerShell/NodePingPowerShellPUSH/modules/checksum.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/checksum.ps1
@@ -1,4 +1,4 @@
-$files = Get-Content -Raw -Path checksum.json | ConvertFrom-Json
+$files = Get-Content -Raw -Path modules\checksum.json | ConvertFrom-Json
 
 # SHA1, SHA256, SHA384, SHA512, MD5
 $hash_algorithm = "SHA256"
@@ -24,4 +24,4 @@ foreach ( $file in $files ) {
 
 }
 
-Write-Output $hash_status | ConvertTo-Json -Compress
+Write-Output $hash_status

--- a/PowerShell/NodePingPowerShellPUSH/modules/checksum.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/checksum.ps1
@@ -1,0 +1,27 @@
+$files = Get-Content -Raw -Path checksum.json | ConvertFrom-Json
+
+# SHA1, SHA256, SHA384, SHA512, MD5
+$hash_algorithm = "SHA256"
+
+$hash_status=@{}
+
+foreach ( $file in $files ) {
+    $filename = $file.FileName
+    $stored_hash = $file.Hash
+
+    if (( Test-Path $filename )) {
+        $get_hash = Get-FileHash $filename -Algorithm $hash_algorithm
+		$new_hash = $get_hash.Hash
+		
+        if ( $stored_hash -eq $new_hash ) {
+            $hash_status.Add($filename, 1)
+        } else {
+            $hash_status.Add($filename, 0)
+        }        
+    } else {
+        $hash_status.Add($filename, 0)
+    }
+
+}
+
+Write-Output $hash_status | ConvertTo-Json -Compress

--- a/PowerShell/NodePingPowerShellPUSH/modules/drives.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/drives.ps1
@@ -8,4 +8,4 @@ foreach( $drive in $drives ) {
 	}
 }
 
-echo $result | ConvertTo-Json -Compress
+Write-Output $result

--- a/PowerShell/NodePingPowerShellPUSH/modules/fileage.json
+++ b/PowerShell/NodePingPowerShellPUSH/modules/fileage.json
@@ -1,0 +1,29 @@
+[
+	{ 
+		"FileName": "C:\\Users\\Administrator\\Documents\\hello.txt",
+        "Age": 
+        {
+            "days": 0,
+            "hours": 0,
+            "minutes": 0
+        }
+	},
+	{ 
+		"FileName": "C:\\Users\\Administrator\\Desktop\\file1.docx",
+        "Age": 
+        {
+            "days": 0,
+            "hours": 0,
+            "minutes": 0
+        }
+	},
+	{ 
+		"FileName": "C:\\Users\\Administrator\\Documents\\fileage.ps1",
+        "Age": 
+        {
+            "days": 0,
+            "hours": 0,
+            "minutes": 0
+        }
+	}
+]

--- a/PowerShell/NodePingPowerShellPUSH/modules/fileage.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/fileage.ps1
@@ -23,4 +23,4 @@ foreach ( $file in $files.GetEnumerator() ) {
     }
 }
 
-Write-Output $files_status | ConvertTo-Json -Compress
+Write-Output $files_status

--- a/PowerShell/NodePingPowerShellPUSH/modules/fileage_new.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/fileage_new.ps1
@@ -1,0 +1,25 @@
+$files = Get-Content -Raw -Path modules\fileage.json | ConvertFrom-Json
+
+$files_status=@{}
+
+foreach ( $file in $files ) {
+    $filename = $file.FileName
+    $days = $file.Age.days
+    $hours = $file.Age.hours
+    $minutes = $file.Age.minutes
+
+    if ((Test-Path $filename)) {
+        $oldest_age = new-timespan -days $days -hours $hours -minutes $minutes
+        $last_write = (get-item $filename).LastWriteTime
+
+        if (((get-date) - $last_write) -gt $oldest_age) {
+            $files_status.Add($filename, 0)
+        } else {
+            $files_status.Add($filename, 1)
+        }
+    } else {
+        $files_status.Add($filename, 0)
+    }
+}
+
+Write-Output $files_status

--- a/PowerShell/NodePingPowerShellPUSH/modules/memory.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/memory.ps1
@@ -1,4 +1,4 @@
 $memory = Get-WmiObject Win32_OperatingSystem
 $free = [math]::floor( $memory.FreePhysicalMemory / 1024 )
 	
-echo $free
+Write-Output $free

--- a/PowerShell/NodePingPowerShellPUSH/modules/processor.ps1
+++ b/PowerShell/NodePingPowerShellPUSH/modules/processor.ps1
@@ -1,3 +1,3 @@
 $processor = Get-WmiObject Win32_Processor | Measure-Object -property LoadPercentage -Average
 
-echo ([math]::Round( $processor.Average / 100.0, 2 ))
+Write-Output ([math]::Round( $processor.Average / 100.0, 2 ))

--- a/Python/NodePingPythonPUSH/metrics/apcupsd.py
+++ b/Python/NodePingPythonPUSH/metrics/apcupsd.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Checks the status of APC battery banks. Requires apcupsd is installed
+and the apcaccess command is available. If the state changes to
+something other than ONLINE, a fail is sent.
+"""
+
+import subprocess
+from . import _utils
+
+
+def main(system, logger):
+    """
+    Checks the apcups log and checks for any power fail events
+    """
+
+    command = "apcaccess status".split()
+    data = subprocess.check_output(command).split("\n")
+
+    for i in data:
+        if "STATUS" in i:
+            status = i.split()[2]
+
+            if status == "ONLINE":
+                return _utils.report(1)
+            else:
+                return _utils.report(0)

--- a/Python/NodePingPythonPUSH/metrics/checksum.ini
+++ b/Python/NodePingPythonPUSH/metrics/checksum.ini
@@ -1,0 +1,7 @@
+[main]
+file1 = checksum
+file2 = checksum
+
+[settings]
+hash_algorithm = sha256
+

--- a/Python/NodePingPythonPUSH/metrics/checksum.py
+++ b/Python/NodePingPythonPUSH/metrics/checksum.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Looks at the checksum of provided files and sees if they match
+the provided checksum for the file. The check will pass if the
+checksums match, or fail if the checksums don't match or the
+file is missing
+
+NOTE: The checksums are stored in a separate checksums.ini
+file that SHOULD be kept in a read-only setting to reduce
+the chances of any possible checksum tampering.
+"""
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+import hashlib
+from os.path import isfile, dirname, realpath
+from . import _utils
+
+DIR_PATH = dirname(realpath(__file__))
+FILENAME = __file__.replace('py', 'ini').split("/")[-1]
+CONFIGFILE = DIR_PATH + "/" + FILENAME
+
+
+def get_hash(f, algorithm):
+    """
+    Checks the algorithm in the config file to see if it is
+    available in hashlib. If so, the checksum is returned
+    from that algorithm. Otherwise, an exception is thrown
+    """
+
+    # md5(), sha1(), sha224(), sha256(), sha384(), and sha512()
+    if algorithm == "md5":
+        hasher = hashlib.md5()
+    elif algorithm == "sha1":
+        hasher = hashlib.sha1()
+    elif algorithm == "sha224":
+        hasher = hashlib.sha224()
+    elif algorithm == "sha256":
+        hasher = hashlib.sha256()
+    elif algorithm == "sha384":
+        hasher = hashlib.sha384()
+    elif algorithm == "sha512":
+        hasher = hashlib.sha512()
+    else:
+        hasher = hashlib.sha256()
+
+    with open(f, 'rb') as afile:
+        data = afile.read()
+        hasher.update(data)
+        checksum = hasher.hexdigest()
+
+    return checksum
+
+
+def main(system, logger):
+    """
+    Opens config file and checks the checksums provided to
+    their corresponding file.
+    """
+
+    results = {}
+
+    config = configparser.RawConfigParser()
+
+    if isfile(CONFIGFILE):
+        config.read(CONFIGFILE)
+    else:
+        config.add_section('main')
+        config.add_section('settings')
+        config.set('main', 'file1', 'checksum')
+        config.set('main', 'file2', 'checksum')
+        config.set('settings', 'hash_algorithm', 'sha256')
+
+        with open(CONFIGFILE, 'wb') as configfile:
+            config.write(configfile)
+
+    files = config.options('main')
+    algorithm = config.get('settings', 'hash_algorithm')
+
+    for f in files:
+        saved_checksum = config.get('main', f)
+
+        if isfile(f):
+            # Hash is collected for each file so user has
+            # choice in algorithm per file
+            checksum = get_hash(f, algorithm)
+
+            if saved_checksum == checksum:
+                results.update({f: 1})
+            else:
+                results.update({f: 0})
+        else:
+            results.update({f: 0})
+
+    return _utils.report(results)


### PR DESCRIPTION
## New modules

### Checksum
This module can be used to monitor the checksum of selected files. Select the desired hashing method for your files and presupply the hash you want to match in the designated config file for the module.

Modules created for Python, POSIX, and PowerShell

### APC battery bank monitoring
This module will return pass/fail if the status changes from ONLINE for the battery bank. This assumes the battery bank can be accessed with the `apcaccess` command-line utility. 

Modules created for Python and POSIX

## PowerShell tweaks
- Changes were made to how data from the modules is collected by the main script. The difference is the main script does the conversion to JSON so all you need to do is simply `echo` or `Write-Output` the data from your module. The modules were adjusted accordingly.
- Now fileage and checksum will read the necessary data from a JSON file instead of supplying the data in the script. Fileage was updated to match the design that already exists in checksum.