### PR TITLE
Updates to POSIX tested OSes + 1 fix

### DIFF
--- a/POSIX/NodePingPUSHClient/README.md
+++ b/POSIX/NodePingPUSHClient/README.md
@@ -7,10 +7,11 @@ A client for the NodePing PUSH check (<https://nodeping.com/push_check.html>) fo
 - CentOS 5
 - CentOS 6
 - CentOS 7
-- Debian 9 *
-- Devuan 2 *
+- Debian 9
+- Devuan 2
 - Fedora 28
-- OpenBSD 6.3
+- FreeBSD 11.2, 12.0
+- OpenBSD 6.5
 - OpenSUSE LEAP 15
 - Raspbian STRETCH
 - Ubuntu 14.04

--- a/POSIX/NodePingPUSHClient/README.md
+++ b/POSIX/NodePingPUSHClient/README.md
@@ -9,7 +9,7 @@ A client for the NodePing PUSH check (<https://nodeping.com/push_check.html>) fo
 - CentOS 7
 - Debian 9
 - Devuan 2
-- Fedora 28
+- Fedora 29, 30
 - FreeBSD 11.2, 12.0
 - OpenBSD 6.5
 - OpenSUSE LEAP 15

--- a/POSIX/NodePingPUSHClient/modules/checksum/checksum.sh
+++ b/POSIX/NodePingPUSHClient/modules/checksum/checksum.sh
@@ -19,7 +19,7 @@ if [ $OS = "Linux" ]; then
     else
 	command="sha256sum"
     fi
-elif [ $OS = "FreeBSD" ]; then
+elif [ $OS = "FreeBSD" ] || [ $OS = "OpenBSD" ]; then
     if [ $hash_type = "sha1" ]; then
 	command="sha1"
     elif [ $hash_type = "sha256" ]; then
@@ -44,7 +44,7 @@ cat $checksums_file | while read -r line; do
     if [ -f $name ]; then
 	if [ $OS = "Linux" ]; then
 	    run_sum=$($command $name | awk '{printf $1}')
-	elif [ $OS = "FreeBSD" ]; then
+	elif [ $OS = "FreeBSD" ] || [ $OS = "OpenBSD" ]; then
 	    run_sum=$($command $name | awk '{printf $4}')
 	fi
 


### PR DESCRIPTION
Updated OSes tested with POSIX to include the latest OpenBSD, both supported versions of FreeBSD, Fedora 29/30

checksum.sh didn't have OpenBSD as an OS option, so any OS looking at checksums would fail since it didn't match the OS. Added OpenBSD so it works properly