### PR TITLE
Same logfile issue applied to the error log file for Python2/3

### DIFF
--- a/Python/NodePingPythonPUSH/NodePingPythonPUSH.py
+++ b/Python/NodePingPythonPUSH/NodePingPythonPUSH.py
@@ -214,8 +214,7 @@ class Config(object):
         if self.log:
             self.logsize = to_positive_int(ini, 'logging', 'logsize')
             self.logfile = join(working_path, ini.get('logging', 'logfile'))
-            self.logerror = realpath(
-                expanduser(ini.get('logging', 'logerror')))
+            self.logerror = join(working_path, ini.get('logging', 'logfile'))
             for file in (self.logfile, self.logerror):
                 file = file if isfile(file) else dirname(file)
                 # if not os.access(self.logfile, os.W_OK):

--- a/Python3/NodePingPython3PUSH/NodePingPythonPUSH.py
+++ b/Python3/NodePingPython3PUSH/NodePingPythonPUSH.py
@@ -214,8 +214,7 @@ class Config(object):
         if self.log:
             self.logsize = to_positive_int(ini, 'logging', 'logsize')
             self.logfile = join(working_path, ini.get('logging', 'logfile'))
-            self.logerror = realpath(
-                expanduser(ini.get('logging', 'logerror')))
+            self.logerror = join(working_path, ini.get('logging', 'logfile'))
             for file in (self.logfile, self.logerror):
                 file = file if isfile(file) else dirname(file)
                 # if not os.access(self.logfile, os.W_OK):


### PR DESCRIPTION
In the last commit finding push.log in its unexpected directory was fixed for the standard info log. However, the fix wasn't applied to the error log too. This fixes the error log being in an unwanted directory.