### PR TITLE
Updated clients & documentation to handle timeouts and retry connections

### DIFF
--- a/POSIX/NodePingPUSHClient/NodePingPUSH.sh
+++ b/POSIX/NodePingPUSHClient/NodePingPUSH.sh
@@ -5,6 +5,8 @@ pathtomoduleconfig='/full/path/to/moduleconfig'
 logfilepath='/full/path/to/logfile/NodePingPUSH.log'
 debug=0
 log=0
+retries=3
+timeout=5
 
 for var in "$@"
 do
@@ -22,16 +24,16 @@ json=''
 
 while IFS=$'=' read -r module filename
 do
-	
+
 	result=$($filename);
-	
+
 	if [ -z "$json" ]
 	then
 		json="\"$module\":$result"
 	else
 		json="$json,\"$module\":$result"
 	fi
-	
+
 done < "$pathtomoduleconfig"
 
 json="{\"data\":{$json}}"
@@ -45,15 +47,30 @@ else
 	then
 		echo "$(date) => $json" >> $logfilepath
 	fi
-	
-	response=$(curl -s -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "$json" "$url")
-	code=$(echo "$response" | tail -n1)
-	response=$(echo "$response" | sed '$d')
-	
-	if [ $log = 1 ]
-	then
-		echo "$(date) <= $code $response" >> $logfilepath
-	fi
-	
+
+	# Tries to connect once and then retries if fails $retries more times
+	tries=$(($retries + 1))
+
+	while [ $tries -gt 0 ]
+	do
+		response=$(curl --connect-timeout $timeout -s -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "$json" "$url")
+		code=$(echo "$response" | tail -n1)
+		# 200 means it went through successfully, 409 means throttled, but it still connected
+		good_response=$(echo $response | grep -c -E '200|409')
+		response=$(echo "$response" | sed '$d')
+
+		# If no 200 or 409, subract from our retry count. Otherwise, break from the loop and continue
+		if [ $good_response = 0 ]
+		then
+			tries=$(($tries - 1))
+		else
+			break
+		fi
+	done
+fi
+
+if [ $log = 1 ]
+then
+	echo "$(date) <= $code $response" >> $logfilepath
 fi
 #

--- a/POSIX/NodePingPUSHClient/README.md
+++ b/POSIX/NodePingPUSHClient/README.md
@@ -8,6 +8,7 @@ A client for the NodePing PUSH check (<https://nodeping.com/push_check.html>) fo
 - CentOS 6
 - CentOS 7
 - Debian 9
+- Debian 10
 - Devuan 2
 - Fedora 29, 30
 - FreeBSD 11.2, 12.0
@@ -37,6 +38,10 @@ url='https://push.nodeping.com/v1?id=201808131639R5ZBF-9TXFFET4&checktoken=EPRFL
 Modify the 'NodePingPUSH.sh' file and edit the pathtomoduleconfig on line 4 to be the absolute path of the moduleconfig file.
 
 Modify the 'NodePingPUSH.sh' file and edit the logfilepath on line 5 to be the absolute path that you want the logfile at.
+
+Modify the 'NodePingPUSH.sh' file and edit the retries on line 8 to set the number of times you want the client to retry connecting if the client is unable to connect the first time.
+
+Modify the 'NodePingPUSH.sh' file and edit the timeout on line 9 to determine how many seconds you want to timeout the connection if the server cannot be reached.
 
 ## Usage
 
@@ -93,6 +98,6 @@ For examples, see the modules in the metrics directory.
 ## Contributions
 
 Found a bug? Built a cool module for xyz? Send it to us!
-We'll encourage pull requests for any changes or additions to the clients, new modules, or documentation.
+We encourage pull requests for any changes or additions to the clients, new modules, or documentation.
 
 copyright NodePing LLC 2019

--- a/PowerShell/NodePingPowerShellPUSH/README.md
+++ b/PowerShell/NodePingPowerShellPUSH/README.md
@@ -9,6 +9,8 @@ Modify the 'NodePingPUSH.ps1' file and set the check id and check token on lines
 Replace "Your Check ID here" with your NodePing check id (found in the check drawer  - click on the check name).
 Also replace "Your Check Token here" with your NodePing check token (also found in the check drawer)
 
+You can also modify the retries variable to change how many times you want the client to try reconnecting to the PUSH servers on line 7 as well as the timeout value on line 6 to determine how many seconds to wait to consider the connection timed out.
+
 Example:
 
 ```sh

--- a/Python/NodePingPythonPUSH/NodePingPythonPUSH.py
+++ b/Python/NodePingPythonPUSH/NodePingPythonPUSH.py
@@ -146,18 +146,26 @@ def post_results(results, config):
     Updates and returns the `results` to include the status code and JSON
     response by the server.
     """
-    try:
-        request = urlopen(
-            Request(
-                config.url,
-                data=json.dumps(results),
-                headers={'Content-Type': 'application/json'}))
-    except URLError as err:
-        panic('Failed to POST results to {config.url}: {err}.'.format(
-            **locals()))
-    else:
-        results['status_code'] = request.getcode()
-        results['json_response'] = request.read()
+
+    retry = config.retries + 1
+
+    while retry > 0:
+        try:
+            request = urlopen(
+                Request(
+                    config.url,
+                    data=json.dumps(results),
+                    headers={'Content-Type': 'application/json'}),
+                timeout=config.timeout)
+        except URLError as err:
+            retry -= 1
+            if retry == 0:
+                panic('Failed to POST results to {config.url}: {err}.'.format(
+                    **locals()))
+        else:
+            results['status_code'] = request.getcode()
+            results['json_response'] = request.read()
+            break
 
     return results
 
@@ -242,6 +250,8 @@ class Config(object):
                   'not be blank.')
         self.url = 'https://{url.path}?id={id_}&checktoken={checktoken}'.format(
             **locals())
+        self.timeout = int(ini.get('server', 'timeout'))
+        self.retries = int(ini.get('server', 'retries'))
 
         # Metrics modules
         self.modules = []

--- a/Python/NodePingPythonPUSH/README.md
+++ b/Python/NodePingPythonPUSH/README.md
@@ -5,9 +5,11 @@ This has been tested on python 2.7.x and popular Linux distros, FreeBSD, OpenBSD
 
 ## Configuration
 
-Modify the 'config.ini' file and set the check id and check token on lines 9 and 10:
+Modify the 'config.ini' file and set the check id and check token on lines 15 and 16:
 Replace YourCheckID with your NodePing check id (found in the check drawer  - click on the check name).
 Also replace YourCheckToken with your NodePing check token (also found in the check drawer)
+
+You can also modify the retries variable to change how many times you want the client to try reconnecting to the PUSH servers on line 13 as well as the timeout value on line 11 to determine how many seconds to wait to consider the connection timed out.
 
 Example:
 

--- a/Python/NodePingPythonPUSH/config.ini
+++ b/Python/NodePingPythonPUSH/config.ini
@@ -6,6 +6,12 @@
 force_tls =  yes
 # The base URL (without the query string) to POST the metrics to.
 url = push.nodeping.com/v1
+# The timeout in seconds for retries connecting to submit results
+# Setting the timeout to 0 will result in a failed connection.
+timeout = 5
+# Number of retries if a connection cannot be made
+retries = 3
+
 id = YourCheckID
 checktoken = YourCheckToken
 

--- a/Python3/NodePingPython3PUSH/README.md
+++ b/Python3/NodePingPython3PUSH/README.md
@@ -5,9 +5,11 @@ This has been tested on python 3.4.x and popular Linux distros, FreeBSD, OpenBSD
 
 ## Configuration
 
-Modify the 'config.ini' file and set the check id and check token on lines 9 and 10:
+Modify the 'config.ini' file and set the check id and check token on lines 15 and 16:
 Replace YourCheckID with your NodePing check id (found in the check drawer  - click on the check name).
 Also replace YourCheckToken with your NodePing check token (also found in the check drawer)
+
+You can also modify the retries variable to change how many times you want the client to try reconnecting to the PUSH servers on line 13 as well as the timeout value on line 11 to determine how many seconds to wait to consider the connection timed out.
 
 Example:
 

--- a/Python3/NodePingPython3PUSH/config.ini
+++ b/Python3/NodePingPython3PUSH/config.ini
@@ -6,6 +6,12 @@
 force_tls =  yes
 # The base URL (without the query string) to POST the metrics to.
 url = push.nodeping.com/v1
+# The timeout in seconds for retries connecting to submit results
+# Setting the timeout to 0 will result in a failed connection.
+timeout = 5
+# Number of retries if a connection cannot be made
+retries = 3
+
 id = YourCheckID
 checktoken = YourCheckToken
 


### PR DESCRIPTION
## Changes

### POSIX

__NodePingPUSH.sh__

* Added retries variable with default of 3 retries
* Added timeout variable with default of 5 seconds
* Added timeout and retry functionality to result submission
* Removed extra tabs from lines

__README__

* Updated to match changes to the client script
* Added Debian 10 to tested OSes

### PowerShell

__NodePingPUSH.ps1__

* Added retries variable with default of 3 retries
* Added timeout variable with default of 5 seconds
* Added timeout and retry functionality to result submission
* Changes made compatible with PowerShell 5

__README__

* Updated to match changes to the client script

### Python2/3

__NodePingPythonPUSH.py__

* Added timeout and retry variables
* Put retry code in while loop to retry failing connections to PUSH servers
* **Python3** removed the TODO since it was already complete

__config.ini__

* Added retries variable with default of 3 retries
* Added timeout variable with default of 5 seconds