### PR TITLE
POSIX net_utilization skips interface if not present

### DIFF
--- a/POSIX/NodePingPUSHClient/modules/net_utilization/net_utilization.sh
+++ b/POSIX/NodePingPUSHClient/modules/net_utilization/net_utilization.sh
@@ -21,6 +21,10 @@ fi
 # Checks network utilization per interface
 for interface in $interfaces; do 
 
+    if [ ! -f "/sys/class/net/$interface/statistics/rx_bytes" ]; then
+        continue
+    fi
+
     echo "$sep"
 
     # If there is an existing entry and each_push, gather the info


### PR DESCRIPTION
If an interface did not exist, the script would submit broken JSON. This will just ignore the nonexistent interface.