### PR TITLE
cpu_utilization added FreeBSD and fixed issue

### DIFF
--- a/POSIX/NodePingPUSHClient/modules/cpu_utilization/cpu_utilization.sh
+++ b/POSIX/NodePingPUSHClient/modules/cpu_utilization/cpu_utilization.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env sh
 
 # Get CPU utilization
-top -bn2 | grep "%Cpu" | tail -n1 | awk '{printf (100 - $8)}'
+
+os=$(uname)
+
+if [ "$os" = "Linux" ]; then
+    cpu_info=$(top -bn2 | grep "%Cpu" | tail -n1)
+    column_count=$(echo $cpu_info | awk -F ' ' '{printf NF; exit}')
+
+    # If the CPU is 100% idle, top doesn't put a space between id, and 100
+    # so this adds the space back to not mess with awk
+    if [ $column_count -eq 16 ]; then
+        cpu_info=$(echo "$cpu_info" | sed 's/ni,100.0/ni, 100.0/g')
+    fi
+
+    echo "$cpu_info" | awk '{printf (100 - $8)}'
+elif [ "$os" = "FreeBSD" ]; then
+    top -d2 | grep "CPU:" | tail -n1 | awk '{print $(NF-1)}' | sed 's/%//g'
+fi


### PR DESCRIPTION
cpu_utilization shell script would output the value incorrectly if the CPU was 100% idle. This is because top wouldn't provide a space, so the column count was off. This addresses that and adds a FreeBSD section