### PR TITLE
Fixed regex for finding CIDR in POSIX ip_addr

### DIFF
--- a/POSIX/NodePingPUSHClient/modules/ip_addrs/ip_addrs.sh
+++ b/POSIX/NodePingPUSHClient/modules/ip_addrs/ip_addrs.sh
@@ -14,7 +14,7 @@ else
 fi
 
 for ip in $ips; do
-    cidr=$(echo $ip | grep -oE '(100$)|/[1-9]{1,3}')
+    cidr=$(echo $ip | grep -oE '(100$)|/[0-9]{1,3}')
 
     if [ "$os" = "Linux" ]; then
         ip=$(echo $ip | sed "s#$cidr##g" | xargs)


### PR DESCRIPTION
The previous regex would not properly handle /3x CIDR. So `/30` would become `/3` and break. This fixes any /3x CIDR value