### PR TITLE
Update IP addresses in dnslookup module

### DIFF
--- a/POSIX/NodePingPUSHClient/modules/dnslookup/variables.sh
+++ b/POSIX/NodePingPUSHClient/modules/dnslookup/variables.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # DNS server IP to query
-dns_ip="9.9.9.9"
+dns_ip="84.22.105.156"
 
 # Hostname to resolve
 to_resolve="nodeping.com"

--- a/POSIX/NodePingPUSHClient/modules/dnslookup/variables.sh
+++ b/POSIX/NodePingPUSHClient/modules/dnslookup/variables.sh
@@ -7,6 +7,6 @@ dns_ip="9.9.9.9"
 to_resolve="nodeping.com"
 
 # Expected IP or hostname as output. Deliminate results with spaces
-expected_output="167.114.101.137"
+expected_output="51.79.77.52"
 
 record_type="A"

--- a/Python/NodePingPythonPUSH/metrics/dnslookup/config.py
+++ b/Python/NodePingPythonPUSH/metrics/dnslookup/config.py
@@ -1,5 +1,5 @@
 # DNS server IP to query
-dns_ip = "64.34.204.155"
+dns_ip = "84.22.105.156"
 
 # Hostname to resolve
 to_resolve = "nodeping.com"

--- a/Python/NodePingPythonPUSH/metrics/dnslookup/config.py
+++ b/Python/NodePingPythonPUSH/metrics/dnslookup/config.py
@@ -6,7 +6,7 @@ to_resolve = "nodeping.com"
 
 # Expected IP or hostname as output. Deliminate results with spaces
 # Multiple outputs should be put in a list
-expected_output = "167.114.101.137"
+expected_output = "51.79.77.52"
 
 # Query type
 query_type = "A"

--- a/Python3/NodePingPython3PUSH/metrics/dnslookup/config.py
+++ b/Python3/NodePingPython3PUSH/metrics/dnslookup/config.py
@@ -1,5 +1,5 @@
 # DNS server IP to query
-dns_ip = "64.34.204.155"
+dns_ip = "84.22.105.156"
 
 # Hostname to resolve
 to_resolve = "nodeping.com"

--- a/Python3/NodePingPython3PUSH/metrics/dnslookup/config.py
+++ b/Python3/NodePingPython3PUSH/metrics/dnslookup/config.py
@@ -6,7 +6,7 @@ to_resolve = "nodeping.com"
 
 # Expected IP or hostname as output. Deliminate results with spaces
 # Multiple outputs should be put in a list
-expected_output = "167.114.101.137"
+expected_output = "51.79.77.52"
 
 # Query type
 query_type = "A"


### PR DESCRIPTION
`64.34.204.155` appears to be an old IP address that was used by ns2.nodeping.com, but this IP doesn't seem to be associated with any NodePing authoritative nameservers anymore. This IP doesn't appear to respond to DNS queries anymore.

`167.114.101.137` used to be the IP that nodeping.com resolved to, but this is also an old IP and the current domain only has one A record for `51.79.77.52`.

In the current state, the dnslookup module errors because the default expected output is an old IP address that doesn't match nodeping.com.