### PR TITLE
Change cass module and add Python3 pidht22 module

### DIFF
--- a/POSIX/NodePingPUSHClient/modules/cassandra/cassandra.sh
+++ b/POSIX/NodePingPUSHClient/modules/cassandra/cassandra.sh
@@ -2,22 +2,6 @@
 
 # Collects the status of Cassandra servers in a cluster and returns the values such as "UN" and "DN"
 
-cassstatus=$(nodetool status)
-
-sep=''
-echo '{'
-echo "$cassstatus" | while read -r line; do
-
-    hasip=$(echo $line | awk '{ print $2 }' | egrep '\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}\b' | xargs)
-    if [ -n "$hasip" ]; then
-        echo "$sep"
-        if [ $(echo $line | awk '{ printf $1 }') = "UN" ]; then
-            echo $line | awk '{ printf "\"%s\": 1", $2 }'
-        else
-            echo $line | awk '{ printf "\"%s\": 0", $2 }'
-        fi
-        sep=","
-    fi
-done
-echo '}'
-
+cassstatus=$(nodetool status | grep '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}')
+result=$(echo "$cassstatus" | awk 'NR>1{printf","} {if ($1 == "UN" || $1 == "UJ") printf "\""$2"\": 1"; else printf "\""$2"\": 0" }')
+echo "{$result}"

--- a/Python3/NodePingPython3PUSH/metrics/pidht22/README.md
+++ b/Python3/NodePingPython3PUSH/metrics/pidht22/README.md
@@ -1,0 +1,21 @@
+# pidht22 module
+
+## Description
+
+Use the DHT22 sensor with the Raspberry Pi
+
+Sensor tested: HiLetgo 2pcs DHT22/AM2302 Digital Temperature And Humidity Sensor
+
+## Configuration
+
+UNIT - Set to "F" for Fahrenheit or "C" for Celsius
+PIN - By default this is pin 7, or GPIO 4 on the Raspberry Pi. If using a different pin, consult the documentation
+
+An example of connecting the sensor to the Pi:
+
+* Sensor left pin to pin 2 (5V power) on the Pi
+* Sensor middle pin to pin 7 (GPIO 4) on the Pi
+* Sensor right pin to pin 9 (Ground) on the Pi
+
+Pi pin layout: https://www.raspberrypi.com/documentation/computers/raspberry-pi.html
+board module: https://learn.adafruit.com/arduino-to-circuitpython/the-board-module

--- a/Python3/NodePingPython3PUSH/metrics/pidht22/config.py
+++ b/Python3/NodePingPython3PUSH/metrics/pidht22/config.py
@@ -1,0 +1,7 @@
+import board
+# F for Fahrenheit, C for Celsius
+UNIT="F"
+# The GPIO number
+# Pi pin layout: https://www.raspberrypi.com/documentation/computers/raspberry-pi.html
+# board module: https://learn.adafruit.com/arduino-to-circuitpython/the-board-module
+PIN=board.D4

--- a/Python3/NodePingPython3PUSH/metrics/pidht22/pidht22.py
+++ b/Python3/NodePingPython3PUSH/metrics/pidht22/pidht22.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""NodePing DHT22 PUSH module."""
+
+import adafruit_dht
+from time import sleep
+from . import config
+
+def main(system, logger):
+    """Get the temp, humidity, from DHT22 sensor."""
+
+    pin = config.PIN
+    device = adafruit_dht.DHT22(pin)
+    environment = {}
+
+    while True:
+        try:
+            temperature = device.temperature
+            humidity = device.humidity
+
+            device.exit()
+        except Exception as err:
+            logger.error('metrics.pidht22: {err}!'.format(**locals()))
+            sleep(2)
+            continue
+        else:
+            break
+    
+    if humidity is not None:
+        environment.update({"humidity": int(humidity)})
+    if temperature is not None:
+        if config.UNIT.upper() == "F":
+            return_temp = int((temperature*1.8) + 32)
+        else:
+            return_temp = temperature
+
+        environment.update({"temperature": round(return_temp, 2)})
+
+    return environment


### PR DESCRIPTION
Cleaned up the cassandra module and consider `UJ` as passing.

Added the pidht22 module for the Python3 client.